### PR TITLE
## Feature: Display Map and Address on Place Details Screen

### DIFF
--- a/lib/screens/new_place.dart
+++ b/lib/screens/new_place.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:maplace/models/place.dart';
 
 import 'package:maplace/providers/user_places.dart';
 
@@ -15,22 +16,24 @@ class NewPlaceScreen extends ConsumerStatefulWidget {
 }
 
 class _NewPlaceScreenState extends ConsumerState<NewPlaceScreen> {
+  // These variables are here to help with states
   final _titleController = TextEditingController();
   File? _selectedImage;
+  PlaceLocation? _selectedLocation;
 
   void _savePlace() {
     final enteredTitle = _titleController.text;
 
-    if (enteredTitle.isEmpty && mounted || _selectedImage == null && mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Please enter a title'),
-        ),
-      );
+    if (mounted && (enteredTitle.isEmpty  || _selectedImage == null || _selectedLocation == null)) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Please fill all information.')));
       return;
     }
 
-    ref.read(userPlacesProvider.notifier).addPlace(enteredTitle, _selectedImage!);
+    ref
+        .read(userPlacesProvider.notifier)
+        .addPlace(enteredTitle, _selectedImage!, _selectedLocation!);
     Navigator.of(context).pop();
   }
 
@@ -63,10 +66,11 @@ class _NewPlaceScreenState extends ConsumerState<NewPlaceScreen> {
               ),
               // Image Input
               const SizedBox(height: 10),
-              ImageInput(onPickImage: (image) => _selectedImage = image
-              ),
+              ImageInput(onPickImage: (image) => _selectedImage = image),
               const SizedBox(height: 10),
-              InputLocation(),
+              InputLocation(
+                onSelectPlace: (location) => _selectedLocation = location,
+              ),
               const SizedBox(height: 16),
               ElevatedButton.icon(
                 onPressed: _savePlace,

--- a/lib/screens/places_details.dart
+++ b/lib/screens/places_details.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:maplace/models/place.dart';
+import 'package:maplace/utils/location_image_url.dart';
 
 class PlaceDetailsScreen extends ConsumerWidget {
   const PlaceDetailsScreen(this.place, {super.key});
@@ -9,19 +9,56 @@ class PlaceDetailsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Scaffold(appBar: AppBar (
-      title: Text(place.title),
-    ),
+    final address = place.location?.address ?? '';
+    final locationImage = LocationImageUrl().locationImage(place.location);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(place.title)),
       body: Stack(
         children: [
           Image.file(
-           place.image,
+            place.image,
             fit: BoxFit.cover,
             width: double.infinity,
             height: double.infinity,
-          )
+          ),
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: Column(
+              children: [
+                CircleAvatar(
+                  radius: 70,
+                  backgroundImage: NetworkImage(locationImage),
+                ),
+                Container(
+                  alignment: Alignment.center,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 24,
+                    vertical: 16,
+                  ),
+                  decoration: const BoxDecoration(
+                    gradient: LinearGradient(colors: [
+                      Colors.transparent,
+                      Colors.black54,
+                    ],
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    ),
+                  ),
+                  child: Text(
+                    address,
+                    style: Theme.of(context).textTheme.titleLarge!.copyWith(
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
         ],
-      )
+      ),
     );
   }
 }

--- a/lib/utils/location_image_url.dart
+++ b/lib/utils/location_image_url.dart
@@ -1,0 +1,13 @@
+import 'package:maplace/models/place.dart';
+import 'package:maplace/secrets/secrets.dart' as secrets;
+
+class LocationImageUrl {
+  String locationImage(PlaceLocation? location) {
+    if (location == null) {
+      return '';
+    }
+    final lat = location.latitude ;
+    final lng = location.longitude;
+    return 'https://maps.googleapis.com/maps/api/staticmap?center=$lat,$lng&zoom=13&size=600x300&maptype=roadmap&markers=color:red%7Clabel:S%7C$lat,$lng&key=${secrets.googleMapsApiKey}';
+  }
+}

--- a/lib/widgets/input_location.dart
+++ b/lib/widgets/input_location.dart
@@ -17,6 +17,13 @@ class _InputLocationState extends State<InputLocation> {
   PlaceLocation? _pickedLocation;
   var _isGettingLocation = false;
 
+  String get locationImage {
+    if (_pickedLocation == null) return '';
+    final lat = _pickedLocation!.latitude;
+    final lng = _pickedLocation!.longitude;
+    return 'https://maps.googleapis.com/maps/api/staticmap?center=$lat,$lng&zoom=13&size=600x300&maptype=roadmap&markers=color:red%7Clabel:S%7C$lat,$lng&key=${Secrets.googleMapsApiKey}';
+  }
+
   void _getCurrentLocation() async {
     Location location = Location();
 
@@ -79,6 +86,15 @@ class _InputLocationState extends State<InputLocation> {
         decorationColor: Theme.of(context).colorScheme.onSurfaceVariant,
       ),
     );
+
+    if (_pickedLocation != null) {
+      previewContent = Image.network(
+        locationImage,
+        fit: BoxFit.cover,
+        height: double.infinity,
+        width: double.infinity,
+      );
+    }
 
     if (_isGettingLocation) {
       previewContent = const CircularProgressIndicator();

--- a/lib/widgets/input_location.dart
+++ b/lib/widgets/input_location.dart
@@ -4,7 +4,8 @@ import 'package:http/http.dart' as http;
 import 'package:location/location.dart';
 
 import 'package:maplace/models/place.dart';
-import 'package:maplace/secrets/secrets.dart' as Secrets;
+import 'package:maplace/secrets/secrets.dart' as secrets;
+import 'package:maplace/utils/location_image_url.dart';
 
 class InputLocation extends StatefulWidget {
   const InputLocation({super.key, required this.onSelectPlace});
@@ -20,10 +21,7 @@ class _InputLocationState extends State<InputLocation> {
   var _isGettingLocation = false;
 
   String get locationImage {
-    if (_pickedLocation == null) return '';
-    final lat = _pickedLocation!.latitude;
-    final lng = _pickedLocation!.longitude;
-    return 'https://maps.googleapis.com/maps/api/staticmap?center=$lat,$lng&zoom=13&size=600x300&maptype=roadmap&markers=color:red%7Clabel:S%7C$lat,$lng&key=${Secrets.googleMapsApiKey}';
+    return LocationImageUrl().locationImage(_pickedLocation);
   }
 
   void _getCurrentLocation() async {
@@ -62,7 +60,7 @@ class _InputLocationState extends State<InputLocation> {
     }
 
     final url = Uri.parse(
-      'https://maps.googleapis.com/maps/api/geocode/json?latlng=$lat,$lng&key=${Secrets.googleMapsApiKey}',
+      'https://maps.googleapis.com/maps/api/geocode/json?latlng=$lat,$lng&key=${secrets.googleMapsApiKey}',
     );
     final response = await http.get(url);
     final responseData = json.decode(response.body);

--- a/lib/widgets/input_location.dart
+++ b/lib/widgets/input_location.dart
@@ -7,7 +7,9 @@ import 'package:maplace/models/place.dart';
 import 'package:maplace/secrets/secrets.dart' as Secrets;
 
 class InputLocation extends StatefulWidget {
-  const InputLocation({super.key});
+  const InputLocation({super.key, required this.onSelectPlace});
+
+  final void Function(PlaceLocation location) onSelectPlace;
 
   @override
   State<InputLocation> createState() => _InputLocationState();
@@ -74,6 +76,8 @@ class _InputLocationState extends State<InputLocation> {
       );
       _isGettingLocation = false;
     });
+
+    widget.onSelectPlace(_pickedLocation!);
   }
 
   @override

--- a/lib/widgets/places_list.dart
+++ b/lib/widgets/places_list.dart
@@ -39,6 +39,12 @@ class PlacesList extends StatelessWidget {
                   color: theme.colorScheme.onSurface,
                 ),
               ),
+              subtitle: Text(
+                places[index].location?.address ?? '',
+                style: theme.textTheme.bodySmall!.copyWith(
+                  color: theme.colorScheme.onSurface,
+                ),
+              ),
             ),
       );
     }


### PR DESCRIPTION
This pull request implements the functionality to display a map snapshot and the corresponding address on the `PlaceDetailsScreen`. Users will now see a visual representation of the place's location and its formatted address when viewing place details.

**Changes Made:**

*   **`PlaceDetailsScreen.dart`**:
    *   Modified to render a map image (snapshot).
    *   Updated to display the place's address.
*   Leveraged `location_image_url.dart` for generating the map image URL.
*   Ensured picked location data is utilized for displaying the correct map and address.

**How to Test:**

1.  Navigate to the places list.
2.  Select any place to view its details.
3.  **Verify:** The `PlaceDetailsScreen` displays.
4.  **Verify:** A map image representing the place's location is visible.
5.  **Verify:** The correct address for the place is displayed.