### PR TITLE
Feature: Interactive Map, Location Picking, and Dynamic Display

### DIFF
--- a/lib/screens/map.dart
+++ b/lib/screens/map.dart
@@ -21,6 +21,8 @@ class MapScreen extends StatefulWidget {
 }
 
 class _MapScreenState extends State<MapScreen> {
+  LatLng? _pickedLocation;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -34,16 +36,29 @@ class _MapScreenState extends State<MapScreen> {
         ],
       ),
       body: GoogleMap(
+        onTap: (position) {
+          setState(() {
+            _pickedLocation = position;
+          });
+        },
         initialCameraPosition: CameraPosition(
           target: LatLng(widget.location.latitude, widget.location.longitude),
           zoom: 16,
         ),
-        markers: {
-          Marker(
-            markerId: const MarkerId('m1'),
-            position: LatLng(widget.location.latitude, widget.location.longitude),
-          )
-        },
+        markers:
+            _pickedLocation == null && widget.isSelecting
+                ? {}
+                : {
+                  Marker(
+                    markerId: const MarkerId('m1'),
+                    position:
+                        _pickedLocation ??
+                        LatLng(
+                          widget.location.latitude,
+                          widget.location.longitude,
+                        ),
+                  ),
+                },
       ),
     );
   }

--- a/lib/screens/map.dart
+++ b/lib/screens/map.dart
@@ -32,7 +32,9 @@ class _MapScreenState extends State<MapScreen> {
         ),
         actions: [
           if (widget.isSelecting)
-            IconButton(icon: const Icon(Icons.save), onPressed: () {}),
+            IconButton(icon: const Icon(Icons.save), onPressed: () {
+              Navigator.of(context).pop(_pickedLocation);
+            }),
         ],
       ),
       body: GoogleMap(

--- a/lib/screens/map.dart
+++ b/lib/screens/map.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:maplace/models/place.dart';
+
+class MapScreen extends StatefulWidget {
+  const MapScreen({
+    super.key,
+    this.location = const PlaceLocation(
+      latitude: 37.422,
+      longitude: -122.084,
+      address: '',
+    ),
+    this.isSelecting = true,
+  });
+
+  final PlaceLocation location;
+  final bool isSelecting;
+
+  @override
+  State<MapScreen> createState() => _MapScreenState();
+}
+
+class _MapScreenState extends State<MapScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          widget.isSelecting ? 'Pick your Location' : 'Your Location',
+        ),
+        actions: [
+          if (widget.isSelecting)
+            IconButton(icon: const Icon(Icons.save), onPressed: () {}),
+        ],
+      ),
+      body: GoogleMap(
+        initialCameraPosition: CameraPosition(
+          target: LatLng(widget.location.latitude, widget.location.longitude),
+          zoom: 16,
+        ),
+        markers: {
+          Marker(
+            markerId: const MarkerId('m1'),
+            position: LatLng(widget.location.latitude, widget.location.longitude),
+          )
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/places_details.dart
+++ b/lib/screens/places_details.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:maplace/models/place.dart';
+import 'package:maplace/screens/map.dart';
 import 'package:maplace/utils/location_image_url.dart';
 
 class PlaceDetailsScreen extends ConsumerWidget {
   const PlaceDetailsScreen(this.place, {super.key});
+
   final Place place;
 
   @override
@@ -28,9 +30,22 @@ class PlaceDetailsScreen extends ConsumerWidget {
             right: 0,
             child: Column(
               children: [
-                CircleAvatar(
-                  radius: 70,
-                  backgroundImage: NetworkImage(locationImage),
+                GestureDetector(
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder:
+                            (ctx) => MapScreen(
+                              location: place.location!,
+                              isSelecting: false,
+                            ),
+                      ),
+                    );
+                  },
+                  child: CircleAvatar(
+                    radius: 70,
+                    backgroundImage: NetworkImage(locationImage),
+                  ),
                 ),
                 Container(
                   alignment: Alignment.center,
@@ -39,12 +54,10 @@ class PlaceDetailsScreen extends ConsumerWidget {
                     vertical: 16,
                   ),
                   decoration: const BoxDecoration(
-                    gradient: LinearGradient(colors: [
-                      Colors.transparent,
-                      Colors.black54,
-                    ],
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
+                    gradient: LinearGradient(
+                      colors: [Colors.transparent, Colors.black54],
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
                     ),
                   ),
                   child: Text(


### PR DESCRIPTION
This pull request introduces significant enhancements to map functionality, including:
*   Creation of a dedicated `MapScreen`.
*   Ability to tap on the map to select a location.
*   Mechanism to pass the picked location from `MapScreen` back to the input form/location selection area.
*   Displaying the selected or saved place on a dynamic map within the place details view.

**Changes Made:**

*   **`map.dart` (New or significantly updated):**
    *   Created `MapScreen` widget.
    *   Implemented logic to handle map tap gestures for location selection.
*   **`input_location.dart` (or similar form input widget):**
    *   Enabled receiving and processing the picked location data returned from `MapScreen`.
*   **`places_details.dart`**:
    *   Integrated functionality to display the place's location on a dynamic, interactive map (as opposed to just a static image).
    * 
**How to Test:**

1.  **Location Picking:**
    *   Navigate to the screen where users can input or select a location (e.g., when adding a new place).
    *   Trigger the action to open the map for selection.
    *   **Verify:** `MapScreen` opens.
    *   Tap on a location on the map.
    *   **Verify:** A marker or indicator shows the selected point.
    *   Confirm the selection.
    *   **Verify:** The map closes, and the selected location data is populated back in the input form/area.
2.  **Dynamic Map in Place Details:**
    *   Navigate to the places list.
    *   Select a place that has location data.
    *   **Verify:** The `PlaceDetailsScreen` loads.
    *   **Verify:** Instead of (or in addition to) a static map image, an interactive map is displayed showing the place's location.
    *   **Verify:** The map correctly centers on the place's coordinates.